### PR TITLE
메인페이지 레이아웃 (Header, Footer)

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,6 +1,7 @@
 {
   "globals": {
-    "NodeJS": true
+    "NodeJS": true,
+    "JSX": true
   },
   "env": {
     "node": true,

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -27,7 +27,7 @@
     "plugin:import/warnings",
     "plugin:import/typescript",
     "eslint-config-prettier"
-  ],  
+  ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaFeatures": {
@@ -44,7 +44,8 @@
     "import/prefer-default-export": "off",
     "import/no-cycle": "off",
     "import/no-named-as-default": "off",
-    "import/order": [ // import 정렬 및 구분
+    "import/order": [
+      // import 정렬 및 구분
       "error",
       {
         "groups": [
@@ -53,13 +54,28 @@
           "internal",
           ["sibling", "parent", "index"],
           "type",
-          "unknown"  
+          "unknown"
         ],
         "pathGroups": [
           {
             "pattern": "{react*,react*/**}",
             "group": "external",
             "position": "before"
+          },
+          {
+            "pattern": "@/Pages/**",
+            "group": "internal",
+            "position": "after"
+          },
+          {
+            "pattern": "@/Components/**",
+            "group": "internal",
+            "position": "after"
+          },
+          {
+            "pattern": "@/Utils/**",
+            "group": "internal",
+            "position": "after"
           },
           {
             "pattern": "./**/index.tsx",
@@ -77,7 +93,10 @@
         "newlines-between": "always"
       }
     ],
-    "import/extensions": ["error", "ignorePackages", {
+    "import/extensions": [
+      "error",
+      "ignorePackages",
+      {
         "js": "never",
         "jsx": "never",
         "ts": "never",
@@ -91,9 +110,11 @@
     "no-debugger": "warn",
     "no-unused-vars": "warn", // no-unused-vars : 변수 선언 후 반드시 사용 (interface 임시로 변수 선언하고플 때 해결책)
     "no-param-reassign": ["error", { "props": false }],
-    "no-unused-expressions" : [ // 사용 안하는 표현 (예외 제외 Error 표시)
-      "error", {
-        "allowTernary" : true, // a ? b : 0 (삼항 연산자)
+    "no-unused-expressions": [
+      // 사용 안하는 표현 (예외 제외 Error 표시)
+      "error",
+      {
+        "allowTernary": true, // a ? b : 0 (삼항 연산자)
         "allowShortCircuit": true // a || b
       }
     ],

--- a/frontend/firebase.json
+++ b/frontend/firebase.json
@@ -5,5 +5,6 @@
       "firebase.json",
       "**/.*",
       "**/node_modules/**"
+    ]
   }
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,6 +8,7 @@
   </head>
   <body class="full:w-[25rem]">
     <div id="root"></div>
+    <div id="sidemenu"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/frontend/src/404.tsx
+++ b/frontend/src/404.tsx
@@ -1,3 +1,3 @@
-export default function ErrorPage() {
+export default function NotFoundPage() {
   return <>404 page</>;
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,12 +1,15 @@
 import { Routes, Route, useLocation } from 'react-router-dom';
 import axios from 'axios';
 
-import MainPage from '@/Pages/Main';
+import NotFoundPage from '@/404';
+
+import InitialPage from '@/Pages/Initial';
 import SignupPage from '@/Pages/Signup';
 import LoginPage from '@/Pages/Login';
-import Header from '@/Components/Header';
-import ErrorPage from '@/404';
+import MainPage from '@/Pages/Main';
+
 import Footer from '@/Components/Footer';
+import Header from '@/Components/Header';
 
 axios.defaults.withCredentials = true;
 
@@ -17,10 +20,12 @@ function App() {
     <>
       <Header />
       <Routes location={location}>
-        <Route path="*" element={<ErrorPage />} />
-        <Route path="/" element={<MainPage />} />
+        <Route path="*" element={<NotFoundPage />} />
+        <Route path="/" element={<InitialPage />} />
+
         <Route path="/signup" element={<SignupPage />} />
         <Route path="/login" element={<LoginPage />} />
+        <Route path="/main" element={<MainPage />} />
       </Routes>
       <Footer />
     </>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,8 @@ import InitialPage from '@/Pages/Initial';
 import SignupPage from '@/Pages/Signup';
 import LoginPage from '@/Pages/Login';
 import MainPage from '@/Pages/Main';
+import WorkPlanPage from '@/Pages/workPlan';
+import CommutePage from '@/Pages/commute';
 
 import Footer from '@/Components/Footer';
 import Header from '@/Components/Header';
@@ -26,6 +28,8 @@ function App() {
         <Route path="/signup" element={<SignupPage />} />
         <Route path="/login" element={<LoginPage />} />
         <Route path="/main" element={<MainPage />} />
+        <Route path="/workplan" element={<WorkPlanPage />} />
+        <Route path="/commute" element={<CommutePage />} />
       </Routes>
       <Footer />
     </>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,6 +21,7 @@ function App() {
   return (
     <>
       <Header />
+
       <Routes location={location}>
         <Route path="*" element={<NotFoundPage />} />
         <Route path="/" element={<InitialPage />} />

--- a/frontend/src/Components/Button/index.tsx
+++ b/frontend/src/Components/Button/index.tsx
@@ -16,13 +16,15 @@ export const Button: ButtonReturn = (props: ButtonProps) => {
     type = 'button',
     step = 'first',
   } = props;
-  const isDisabled = disabled
-    ? 'opacity-25 cursor-not-allowed active:animate-none hover:animate-none'
-    : '';
-  const commonStyle =
-    'hover:animate-push active:animate-pull w-full font-semibold px-10 py-3 shadow-md rounded-md';
   const [heirarchy, dispatchHeirarchy] = useReducer(ButtonReducer, '');
-  const style = `${commonStyle} ${heirarchy} ${isDisabled}`;
+
+  const commonStyle = 'w-full font-semibold px-10 py-3 shadow-md rounded-md';
+  const toggleButtonDisabled = disabled ? 'opacity-25 cursor-not-allowed' : '';
+  const toggleButtonAnimation = disabled
+    ? 'hover:animate-none active:animate-none'
+    : 'hover:animate-push active:animate-pull';
+
+  const style = `${commonStyle} ${heirarchy} ${toggleButtonDisabled} ${toggleButtonAnimation}`;
 
   useEffect(() => {
     dispatchHeirarchy({ type: step });

--- a/frontend/src/Components/Footer/Hooks/useFooter.tsx
+++ b/frontend/src/Components/Footer/Hooks/useFooter.tsx
@@ -9,11 +9,12 @@ export default function useFooter() {
 
   const changeFooterState = useRecoilCallback(
     () => (props: FooterStateKindsOf) => {
-      const { visible } = props;
+      const { visible, isSelected } = props;
 
       setFooterState({
         ...footerState,
         visible,
+        isSelected,
       });
     },
     [footerState],

--- a/frontend/src/Components/Footer/Hooks/useFooter.tsx
+++ b/frontend/src/Components/Footer/Hooks/useFooter.tsx
@@ -1,0 +1,23 @@
+import { useRecoilState, useRecoilCallback } from 'recoil';
+
+import { setIsFooterLayoutState } from '@/Stores/layout';
+
+import { FooterStateKindsOf } from '..';
+
+export default function useFooter() {
+  const [footerState, setFooterState] = useRecoilState(setIsFooterLayoutState);
+
+  const changeFooterState = useRecoilCallback(
+    () => (props: FooterStateKindsOf) => {
+      const { visible } = props;
+
+      setFooterState({
+        ...footerState,
+        visible,
+      });
+    },
+    [footerState],
+  );
+
+  return { footerState, changeFooterState };
+}

--- a/frontend/src/Components/Footer/index.tsx
+++ b/frontend/src/Components/Footer/index.tsx
@@ -1,16 +1,28 @@
 import React from 'react';
 
-import { FooterProps } from './types';
+import useFooter from './Hooks/useFooter';
 
-type FooterReturn = (props: FooterProps) => React.ReactElement;
+type FooterReturn = () => React.ReactElement;
 
-export const Footer: FooterReturn = (props: FooterProps) => (
-  <>
-    <div className="hidden h-[54px]" />
-    <footer className="hidden fixed bg-blue-500 bottom-0 px-2 py-4 w-full full:w-[25rem]">
-      <span>푸터 영역</span>
-    </footer>
-  </>
-);
+export interface FooterStateKindsOf {
+  visible: boolean;
+}
+
+export const Footer: FooterReturn = () => {
+  const { footerState } = useFooter();
+
+  return (
+    <>
+      {footerState.visible && (
+        <>
+          <div className="hidden h-[54px]" />
+          <footer className="fixed bg-blue-500 bottom-0 px-2 py-4 w-full full:w-[25rem]">
+            <span>푸터 영역</span>
+          </footer>
+        </>
+      )}
+    </>
+  );
+};
 
 export default Footer;

--- a/frontend/src/Components/Footer/index.tsx
+++ b/frontend/src/Components/Footer/index.tsx
@@ -16,8 +16,8 @@ export const Footer: FooterReturn = () => {
       {footerState.visible && (
         <>
           <div className="hidden h-[54px]" />
-          <footer className="fixed bg-blue-500 bottom-0 px-2 py-4 w-full full:w-[25rem]">
-            <span>푸터 영역</span>
+          <footer className="fixed shadow-[0_0px_30px_-10px_rgba(0,0,0,0.250)] bottom-0 px-2 py-4 w-full full:w-[25rem]">
+            <div>버튼 영역</div>
           </footer>
         </>
       )}

--- a/frontend/src/Components/Footer/index.tsx
+++ b/frontend/src/Components/Footer/index.tsx
@@ -1,12 +1,21 @@
 import React from 'react';
+import { AiFillHome, AiFillClockCircle } from 'react-icons/ai';
+import { BsFillCalendarEventFill } from 'react-icons/bs';
 
 import useFooter from './Hooks/useFooter';
 
 type FooterReturn = () => React.ReactElement;
+type FooterBtnKindsOf = 'home' | 'work' | 'commute';
 
-export interface FooterStateKindsOf {
-  visible: boolean;
-}
+export type FooterStateKindsOf =
+  | {
+      visible: boolean;
+      isSelected: FooterBtnKindsOf;
+    }
+  | {
+      visible: boolean;
+      isSelected?: FooterBtnKindsOf;
+    };
 
 export const Footer: FooterReturn = () => {
   const { footerState } = useFooter();
@@ -16,8 +25,19 @@ export const Footer: FooterReturn = () => {
       {footerState.visible && (
         <>
           <div className="hidden h-[54px]" />
-          <footer className="fixed shadow-[0_0px_30px_-10px_rgba(0,0,0,0.250)] bottom-0 px-2 py-4 w-full full:w-[25rem]">
-            <div>버튼 영역</div>
+          <footer className="fixed flex items-center align-middle justify-around shadow-[0_0px_30px_-10px_rgba(0,0,0,0.250)] bottom-0 px-2 py-2 w-full full:w-[25rem]">
+            <div className="text-center flex flex-col h-[3rem] w-[5rem] justify-between items-center">
+              <AiFillHome size="24" />
+              <p>홈</p>
+            </div>
+            <div className="text-center flex flex-col justify-between w-[5rem] h-[3rem] items-center">
+              <BsFillCalendarEventFill className="pt-[0.055rem]" size="21" />
+              <p>근무일정</p>
+            </div>
+            <div className="text-center flex flex-col justify-between h-[3rem] w-[5rem] items-center">
+              <AiFillClockCircle size="23" />
+              <p>출퇴근기록</p>
+            </div>
           </footer>
         </>
       )}

--- a/frontend/src/Components/Footer/index.tsx
+++ b/frontend/src/Components/Footer/index.tsx
@@ -66,7 +66,7 @@ export const Footer: FooterReturn = () => {
   return (
     <>
       <div className="hidden h-[54px]" />
-      <footer className="fixed flex items-center align-middle justify-around shadow-[0_0px_30px_-10px_rgba(0,0,0,0.250)] bottom-0 px-2 py-2 w-full full:w-[25rem]">
+      <footer className="fixed z-9999 bg-white flex items-center align-middle justify-around shadow-[0_0px_30px_-10px_rgba(0,0,0,0.250)] bottom-0 px-2 py-2 w-full full:w-[25rem]">
         <FooterBtnComponent type="home" />
         <FooterBtnComponent type="workplan" />
         <FooterBtnComponent type="commute" />

--- a/frontend/src/Components/Footer/index.tsx
+++ b/frontend/src/Components/Footer/index.tsx
@@ -1,11 +1,14 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { AiFillHome, AiFillClockCircle } from 'react-icons/ai';
 import { BsFillCalendarEventFill } from 'react-icons/bs';
+import { useNavigate } from 'react-router-dom';
 
 import useFooter from './Hooks/useFooter';
+import { FooterBtnWrapper } from './style';
 
 type FooterReturn = () => React.ReactElement;
-type FooterBtnKindsOf = 'home' | 'work' | 'commute';
+type FooterBtnKindsOf = 'home' | 'workplan' | 'commute';
+type FooterBtnComponentMapType = { [k in FooterBtnKindsOf]: JSX.Element };
 
 export type FooterStateKindsOf =
   | {
@@ -19,28 +22,55 @@ export type FooterStateKindsOf =
 
 export const Footer: FooterReturn = () => {
   const { footerState } = useFooter();
+  const navigate = useNavigate();
+
+  const footerVisible = footerState.visible;
+
+  if (!footerVisible) {
+    return <></>;
+  }
+
+  const FooterBtnComponentMap: FooterBtnComponentMapType = {
+    home: (
+      <FooterBtnWrapper
+        onClick={() => navigate('main')}
+        select={footerState.isSelected! === 'home'}
+      >
+        <AiFillHome size="24" />
+        <p>홈</p>
+      </FooterBtnWrapper>
+    ),
+    workplan: (
+      <FooterBtnWrapper
+        onClick={() => navigate('workplan')}
+        select={footerState.isSelected! === 'workplan'}
+      >
+        <BsFillCalendarEventFill className="pt-[0.055rem]" size="21" />
+        <p>근무일정</p>
+      </FooterBtnWrapper>
+    ),
+    commute: (
+      <FooterBtnWrapper
+        onClick={() => navigate('commute')}
+        select={footerState.isSelected! === 'commute'}
+      >
+        <AiFillClockCircle size="23" />
+        <p>출퇴근기록</p>
+      </FooterBtnWrapper>
+    ),
+  };
+
+  const FooterBtnComponent: ({ type }: { type: FooterBtnKindsOf }) => JSX.Element = ({ type }) =>
+    FooterBtnComponentMap[type];
 
   return (
     <>
-      {footerState.visible && (
-        <>
-          <div className="hidden h-[54px]" />
-          <footer className="fixed flex items-center align-middle justify-around shadow-[0_0px_30px_-10px_rgba(0,0,0,0.250)] bottom-0 px-2 py-2 w-full full:w-[25rem]">
-            <div className="text-center flex flex-col h-[3rem] w-[5rem] justify-between items-center">
-              <AiFillHome size="24" />
-              <p>홈</p>
-            </div>
-            <div className="text-center flex flex-col justify-between w-[5rem] h-[3rem] items-center">
-              <BsFillCalendarEventFill className="pt-[0.055rem]" size="21" />
-              <p>근무일정</p>
-            </div>
-            <div className="text-center flex flex-col justify-between h-[3rem] w-[5rem] items-center">
-              <AiFillClockCircle size="23" />
-              <p>출퇴근기록</p>
-            </div>
-          </footer>
-        </>
-      )}
+      <div className="hidden h-[54px]" />
+      <footer className="fixed flex items-center align-middle justify-around shadow-[0_0px_30px_-10px_rgba(0,0,0,0.250)] bottom-0 px-2 py-2 w-full full:w-[25rem]">
+        <FooterBtnComponent type="home" />
+        <FooterBtnComponent type="workplan" />
+        <FooterBtnComponent type="commute" />
+      </footer>
     </>
   );
 };

--- a/frontend/src/Components/Footer/style.tsx
+++ b/frontend/src/Components/Footer/style.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+export const FooterBtnWrapper = ({
+  children,
+  select,
+  onClick,
+}: {
+  children: React.ReactNode;
+  select: boolean;
+  onClick: () => void;
+}) => {
+  const commonStyle = `text-center cursor-pointer flex flex-col h-[3rem] w-[5rem] justify-between items-center`;
+  const selectStyle = `${select ? `text-gray-700` : `text-gray-400`}`;
+  const style = `${commonStyle} ${selectStyle}`;
+
+  if (!select) {
+    return (
+      <button className={style} onClick={onClick}>
+        {children}
+      </button>
+    );
+  }
+  return (
+    <button className={style} onClick={onClick}>
+      {children}
+    </button>
+  );
+};

--- a/frontend/src/Components/Footer/types.ts
+++ b/frontend/src/Components/Footer/types.ts
@@ -1,1 +1,0 @@
-export interface FooterProps {}

--- a/frontend/src/Components/Header/Components/LeftSideMenu.tsx
+++ b/frontend/src/Components/Header/Components/LeftSideMenu.tsx
@@ -1,13 +1,25 @@
-import { useContext } from 'react';
+import { useContext, useRef } from 'react';
 import { AiOutlineRollback } from 'react-icons/ai';
 
 import { LeftSideMenuContext } from '..';
 
 export default function LeftSideMenu() {
   const { menuOpened, setMenuOpened } = useContext(LeftSideMenuContext);
+  const dimArea = useRef<HTMLDivElement>(null);
+  const menuArea = useRef<HTMLDivElement>(null);
 
   const closeMenu = () => {
-    setMenuOpened(false);
+    if (!menuArea.current || !dimArea.current) return;
+    menuArea.current.style.transition = '0.55s';
+    menuArea.current.style.transform = 'translateX(-100%)';
+    menuArea.current.style.opacity = '0';
+
+    dimArea.current.style.transition = '0.55s';
+    dimArea.current.style.opacity = '0';
+
+    setTimeout(() => {
+      setMenuOpened(false);
+    }, 550);
   };
 
   if (!menuOpened) {
@@ -18,9 +30,13 @@ export default function LeftSideMenu() {
     <>
       <div
         onClick={closeMenu}
-        className="fixed z-[10000] top-0 opacity-50 w-full full:w-[25rem] h-screen bg-gray-500"
+        ref={dimArea}
+        className="animation-fade-in fixed z-[10000] top-0 opacity-50 w-full full:w-[25rem] h-screen bg-gray-500"
       ></div>
-      <div className="absolute bg-white z-[10001] top-0 w-[17.5rem] h-screen">
+      <div
+        ref={menuArea}
+        className="absolute animation-slide-in-right bg-white z-[10001] top-0 w-[17.5rem] h-screen"
+      >
         <button className="absolute right-3 top-3" onClick={closeMenu}>
           <AiOutlineRollback size="24" />
         </button>

--- a/frontend/src/Components/Header/Components/LeftSideMenu.tsx
+++ b/frontend/src/Components/Header/Components/LeftSideMenu.tsx
@@ -1,0 +1,30 @@
+import { useContext } from 'react';
+import { AiOutlineRollback } from 'react-icons/ai';
+
+import { LeftSideMenuContext } from '..';
+
+export default function LeftSideMenu() {
+  const { menuOpened, setMenuOpened } = useContext(LeftSideMenuContext);
+
+  const closeMenu = () => {
+    setMenuOpened(false);
+  };
+
+  if (!menuOpened) {
+    return <></>;
+  }
+
+  return (
+    <>
+      <div
+        onClick={closeMenu}
+        className="fixed z-[10000] top-0 opacity-50 w-full full:w-[25rem] h-screen bg-gray-500"
+      ></div>
+      <div className="absolute bg-white z-[10001] top-0 w-[17.5rem] h-screen">
+        <button className="absolute right-3 top-3" onClick={closeMenu}>
+          <AiOutlineRollback size="24" />
+        </button>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/Components/Header/Hooks/useHeader.tsx
+++ b/frontend/src/Components/Header/Hooks/useHeader.tsx
@@ -2,13 +2,13 @@ import { useRecoilState, useRecoilCallback } from 'recoil';
 
 import { setIsHeaderLayoutState } from '@/Stores/layout';
 
-import { HeaderProps } from '../types';
+import { HeaderStateKindsOf } from '../types';
 
 export default function useHeader() {
   const [headerState, setHeaderState] = useRecoilState(setIsHeaderLayoutState);
 
   const changeHeaderState = useRecoilCallback(
-    () => (props: HeaderProps) => {
+    () => (props: HeaderStateKindsOf) => {
       const { visible, leftBtn, rightBtn, headerTitle } = props;
 
       setHeaderState({

--- a/frontend/src/Components/Header/index.tsx
+++ b/frontend/src/Components/Header/index.tsx
@@ -1,22 +1,54 @@
-import React, { useCallback } from 'react';
+import React, {
+  useEffect,
+  useCallback,
+  useState,
+  Context,
+  createContext,
+  Dispatch,
+  SetStateAction,
+} from 'react';
 import { IoIosArrowBack } from 'react-icons/io';
 import { GrInfo } from 'react-icons/gr';
 import { useNavigate } from 'react-router-dom';
+import { AiOutlineMenu } from 'react-icons/ai';
 
 import useHeader from './Hooks/useHeader';
 import { HeaderLeftBtnKindsOf, HeaderRightBtnKindsOf } from './types';
+import LeftSideMenu from './Components/LeftSideMenu';
 
 type HeaderReturn = () => React.ReactElement;
 type LeftBtnComponentMapType = { [k in HeaderLeftBtnKindsOf]: JSX.Element };
 type RightBtnComponentMapType = { [k in HeaderRightBtnKindsOf]: JSX.Element };
 
+type LeftSideMenuContextType = {
+  menuOpened: boolean;
+  setMenuOpened: Dispatch<SetStateAction<boolean>>;
+};
+
+export const initLeftSideMenu: LeftSideMenuContextType = {
+  menuOpened: false,
+  setMenuOpened: () => {},
+};
+
+export const LeftSideMenuContext: Context<LeftSideMenuContextType> =
+  createContext(initLeftSideMenu);
+
 export const Header: HeaderReturn = () => {
+  const [menuOpened, setMenuOpened] = useState<boolean>(false);
   const { headerState } = useHeader();
   const navigate = useNavigate();
 
   const handleGoBack = () => {
     navigate(-1);
   };
+
+  const handleLeftSideMenu = () => {
+    setMenuOpened(true);
+  };
+
+  useEffect(() => {
+    setMenuOpened(false);
+  }, [headerState]);
 
   const leftBtnComponentMap: LeftBtnComponentMapType = {
     empty: <div className="w-[1.5rem]"></div>,
@@ -25,7 +57,11 @@ export const Header: HeaderReturn = () => {
         <IoIosArrowBack size="24" />
       </button>
     ),
-    menu: <div>메뉴</div>,
+    menu: (
+      <button className="flex items-center" onClick={handleLeftSideMenu}>
+        <AiOutlineMenu size="20" />
+      </button>
+    ),
   };
 
   const rightBtnComponentMap: RightBtnComponentMapType = {
@@ -53,12 +89,17 @@ export const Header: HeaderReturn = () => {
     <>
       {headerState.visible && (
         <>
-          <div className="h-[54px]" />
+          <div className="h-[46px] bg-gray-100" />
           <header className="fixed flex justify-between items-center text-center top-0 px-2 py-3 w-full bg-white full:w-[25rem]">
             <LeftBtnComponent />
             <p>{headerState.headerTitle}</p>
             <RightBtnComponent />
           </header>
+          {menuOpened && (
+            <LeftSideMenuContext.Provider value={{ menuOpened, setMenuOpened }}>
+              <LeftSideMenu />
+            </LeftSideMenuContext.Provider>
+          )}
         </>
       )}
     </>

--- a/frontend/src/Components/Header/index.tsx
+++ b/frontend/src/Components/Header/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { IoIosArrowBack } from 'react-icons/io';
+import { GrInfo } from 'react-icons/gr';
 import { useNavigate } from 'react-router-dom';
 
 import useHeader from './Hooks/useHeader';
@@ -19,12 +20,24 @@ export const Header: HeaderReturn = () => {
       {headerState.visible && (
         <>
           <div className="h-[54px]" />
-          <header className="fixed top-0 px-2 py-3 w-full bg-white full:w-[25rem]">
-            {headerState.leftBtn === 'back' && (
-              <button onClick={handleGoBack}>
-                <IoIosArrowBack size="24" />
-              </button>
-            )}
+          <header className="fixed flex justify-between items-center text-center top-0 px-2 py-3 w-full bg-white full:w-[25rem]">
+            <div>
+              {headerState.leftBtn === 'empty' && <div className="w-[1.5rem]"></div>}
+              {headerState.leftBtn === 'back' && (
+                <button className="flex items-center" onClick={handleGoBack}>
+                  <IoIosArrowBack size="24" />
+                </button>
+              )}
+            </div>
+            <p>{headerState.headerTitle}</p>
+            <div>
+              {headerState.rightBtn === 'empty' && <div className="w-[1.5rem]"></div>}
+              {headerState.rightBtn === 'alarm' && (
+                <button className="flex items-center">
+                  <GrInfo size="24" />
+                </button>
+              )}
+            </div>
           </header>
         </>
       )}

--- a/frontend/src/Components/Header/index.tsx
+++ b/frontend/src/Components/Header/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { IoIosArrowBack } from 'react-icons/io';
 import { GrInfo } from 'react-icons/gr';
 import { useNavigate } from 'react-router-dom';
@@ -39,8 +39,15 @@ export const Header: HeaderReturn = () => {
     confirm: <div>확인</div>,
   };
 
-  const LeftBtnComponent: () => JSX.Element = () => leftBtnComponentMap[headerState.leftBtn!];
-  const RightBtnComponent: () => JSX.Element = () => rightBtnComponentMap[headerState.rightBtn!];
+  const LeftBtnComponent: () => JSX.Element = useCallback(
+    () => leftBtnComponentMap[headerState.leftBtn!],
+    [headerState],
+  );
+
+  const RightBtnComponent: () => JSX.Element = useCallback(
+    () => rightBtnComponentMap[headerState.rightBtn!],
+    [headerState],
+  );
 
   return (
     <>

--- a/frontend/src/Components/Header/index.tsx
+++ b/frontend/src/Components/Header/index.tsx
@@ -4,8 +4,11 @@ import { GrInfo } from 'react-icons/gr';
 import { useNavigate } from 'react-router-dom';
 
 import useHeader from './Hooks/useHeader';
+import { HeaderLeftBtnKindsOf, HeaderRightBtnKindsOf } from './types';
 
 type HeaderReturn = () => React.ReactElement;
+type LeftBtnComponentMapType = { [k in HeaderLeftBtnKindsOf]: JSX.Element };
+type RightBtnComponentMapType = { [k in HeaderRightBtnKindsOf]: JSX.Element };
 
 export const Header: HeaderReturn = () => {
   const { headerState } = useHeader();
@@ -15,29 +18,39 @@ export const Header: HeaderReturn = () => {
     navigate(-1);
   };
 
+  const leftBtnComponentMap: LeftBtnComponentMapType = {
+    empty: <div className="w-[1.5rem]"></div>,
+    back: (
+      <button className="flex items-center" onClick={handleGoBack}>
+        <IoIosArrowBack size="24" />
+      </button>
+    ),
+    menu: <div>메뉴</div>,
+  };
+
+  const rightBtnComponentMap: RightBtnComponentMapType = {
+    empty: <div className="w-[1.5rem]"></div>,
+    profile: <div>프로필</div>,
+    alarm: (
+      <button className="flex items-center">
+        <GrInfo size="24" />
+      </button>
+    ),
+    confirm: <div>확인</div>,
+  };
+
+  const LeftBtnComponent: () => JSX.Element = () => leftBtnComponentMap[headerState.leftBtn!];
+  const RightBtnComponent: () => JSX.Element = () => rightBtnComponentMap[headerState.rightBtn!];
+
   return (
     <>
       {headerState.visible && (
         <>
           <div className="h-[54px]" />
           <header className="fixed flex justify-between items-center text-center top-0 px-2 py-3 w-full bg-white full:w-[25rem]">
-            <div>
-              {headerState.leftBtn === 'empty' && <div className="w-[1.5rem]"></div>}
-              {headerState.leftBtn === 'back' && (
-                <button className="flex items-center" onClick={handleGoBack}>
-                  <IoIosArrowBack size="24" />
-                </button>
-              )}
-            </div>
+            <LeftBtnComponent />
             <p>{headerState.headerTitle}</p>
-            <div>
-              {headerState.rightBtn === 'empty' && <div className="w-[1.5rem]"></div>}
-              {headerState.rightBtn === 'alarm' && (
-                <button className="flex items-center">
-                  <GrInfo size="24" />
-                </button>
-              )}
-            </div>
+            <RightBtnComponent />
           </header>
         </>
       )}

--- a/frontend/src/Components/Header/types.ts
+++ b/frontend/src/Components/Header/types.ts
@@ -1,5 +1,5 @@
 type HeaderLeftBtnKindsOf = 'back' | 'menu' | 'empty';
-type HeaderRightBtnKindsOf = 'confirm' | 'profile' | 'empty';
+type HeaderRightBtnKindsOf = 'confirm' | 'profile' | 'alarm' | 'empty';
 
 export interface HeaderStateKindsOf {
   leftBtn?: HeaderLeftBtnKindsOf;

--- a/frontend/src/Components/Header/types.ts
+++ b/frontend/src/Components/Header/types.ts
@@ -1,7 +1,7 @@
 type HeaderLeftBtnKindsOf = 'back' | 'menu' | 'empty';
 type HeaderRightBtnKindsOf = 'confirm' | 'profile' | 'empty';
 
-export interface HeaderProps {
+export interface HeaderStateKindsOf {
   leftBtn?: HeaderLeftBtnKindsOf;
   rightBtn?: HeaderRightBtnKindsOf;
   headerTitle?: string;

--- a/frontend/src/Components/Header/types.ts
+++ b/frontend/src/Components/Header/types.ts
@@ -1,5 +1,5 @@
-type HeaderLeftBtnKindsOf = 'back' | 'menu' | 'empty';
-type HeaderRightBtnKindsOf = 'confirm' | 'profile' | 'alarm' | 'empty';
+export type HeaderLeftBtnKindsOf = 'back' | 'menu' | 'empty';
+export type HeaderRightBtnKindsOf = 'confirm' | 'profile' | 'alarm' | 'empty';
 
 export interface HeaderStateKindsOf {
   leftBtn?: HeaderLeftBtnKindsOf;

--- a/frontend/src/Components/Input/index.tsx
+++ b/frontend/src/Components/Input/index.tsx
@@ -5,7 +5,7 @@ import { InputProps } from './types';
 type InputReturn = (props: InputProps) => React.ReactElement;
 
 export const Input: InputReturn = (props: InputProps) => {
-  const { label, message = '', placeholder = '' } = props;
+  const { label, errorMsg = '', placeholder = '' } = props;
 
   return (
     <>
@@ -17,7 +17,7 @@ export const Input: InputReturn = (props: InputProps) => {
         placeholder={`${placeholder}`}
         id={label}
       />
-      <p className="text-[14px] text-red-500 pb-2">{message}</p>
+      <p className="text-[14px] text-red-500 pb-2">{errorMsg}</p>
     </>
   );
 };

--- a/frontend/src/Components/Input/types.ts
+++ b/frontend/src/Components/Input/types.ts
@@ -1,5 +1,5 @@
 export interface InputProps {
   label: string;
-  message?: string;
+  errorMsg?: string;
   placeholder: string;
 }

--- a/frontend/src/Pages/Initial/index.tsx
+++ b/frontend/src/Pages/Initial/index.tsx
@@ -1,0 +1,36 @@
+import { useEffect } from 'react';
+
+import useHeader from '@/Components/Header/Hooks/useHeader';
+import useFooter from '@/Components/Footer/Hooks/useFooter';
+import Button from '@/Components/Button';
+
+import { InitialPageWrapper } from './style';
+
+export default function InitialPage() {
+  const { changeHeaderState } = useHeader();
+  const { changeFooterState } = useFooter();
+
+  useEffect(() => {
+    changeHeaderState({
+      visible: false,
+    });
+    changeFooterState({ visible: false });
+  }, []);
+
+  return (
+    <InitialPageWrapper>
+      <h1 className="font-bold">시프티에 오신 것을 환영합니다</h1>
+      <div className="w-full flex flex-col gap-4">
+        <div className="flex flex-col gap-4 w-full">
+          <Button kind="a" href="login">
+            로그인
+          </Button>
+          <Button kind="a" href="signup">
+            회원가입
+          </Button>
+        </div>
+        <span>&copy; faketee2022</span>
+      </div>
+    </InitialPageWrapper>
+  );
+}

--- a/frontend/src/Pages/Initial/index.tsx
+++ b/frontend/src/Pages/Initial/index.tsx
@@ -25,7 +25,7 @@ export default function InitialPage() {
           <Button kind="a" href="login">
             로그인
           </Button>
-          <Button kind="a" href="signup">
+          <Button kind="a" href="signup" step="second">
             회원가입
           </Button>
         </div>

--- a/frontend/src/Pages/Initial/style.tsx
+++ b/frontend/src/Pages/Initial/style.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export const InitialPageWrapper = ({ children }: { children: React.ReactNode }) => (
+  <main className="flex flex-col text-center h-full items-center justify-around">{children}</main>
+);

--- a/frontend/src/Pages/Login/index.tsx
+++ b/frontend/src/Pages/Login/index.tsx
@@ -5,11 +5,13 @@ import { useNavigate } from 'react-router-dom';
 import useHeader from '@/Components/Header/Hooks/useHeader';
 import Button from '@/Components/Button';
 import Input from '@/Components/Input';
+import useFooter from '@/Components/Footer/Hooks/useFooter';
 
 import { LoginPageWrapper } from './style';
 
 export default function LoginPage() {
   const { changeHeaderState } = useHeader();
+  const { changeFooterState } = useFooter();
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -17,6 +19,7 @@ export default function LoginPage() {
       visible: true,
       leftBtn: 'back',
     });
+    changeFooterState({ visible: false });
   }, []);
 
   return (

--- a/frontend/src/Pages/Login/index.tsx
+++ b/frontend/src/Pages/Login/index.tsx
@@ -1,14 +1,16 @@
 import { FcGoogle } from 'react-icons/fc';
 import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 
+import useHeader from '@/Components/Header/Hooks/useHeader';
 import Button from '@/Components/Button';
 import Input from '@/Components/Input';
-import useHeader from '@/Components/Header/Hooks/useHeader';
 
 import { LoginPageWrapper } from './style';
 
 export default function LoginPage() {
   const { changeHeaderState } = useHeader();
+  const navigate = useNavigate();
 
   useEffect(() => {
     changeHeaderState({
@@ -25,7 +27,7 @@ export default function LoginPage() {
         <Input label="비밀번호" placeholder="비밀번호를 입력하세요" />
       </form>
       <div className="flex flex-col gap-4 w-full">
-        <Button kind="btn" type="submit">
+        <Button kind="btn" type="submit" onClick={() => navigate('/main')}>
           로그인
         </Button>
         <Button kind="a" href="google" step="second">

--- a/frontend/src/Pages/Main/index.tsx
+++ b/frontend/src/Pages/Main/index.tsx
@@ -12,7 +12,7 @@ export default function MainPage() {
   useEffect(() => {
     changeHeaderState({
       visible: true,
-      leftBtn: 'back',
+      leftBtn: 'menu',
       rightBtn: 'empty',
       headerTitle: '메인 페이지',
     });

--- a/frontend/src/Pages/Main/index.tsx
+++ b/frontend/src/Pages/Main/index.tsx
@@ -1,6 +1,5 @@
 import { useEffect } from 'react';
 
-import Button from '@/Components/Button';
 import useHeader from '@/Components/Header/Hooks/useHeader';
 import useFooter from '@/Components/Footer/Hooks/useFooter';
 
@@ -12,25 +11,18 @@ export default function MainPage() {
 
   useEffect(() => {
     changeHeaderState({
-      visible: false,
+      visible: true,
+      leftBtn: 'back',
+      rightBtn: 'empty',
+      headerTitle: '메인 페이지',
     });
-    changeFooterState({ visible: false });
+    changeFooterState({ visible: true });
   }, []);
 
   return (
     <MainPageWrapper>
-      <h1 className="font-bold">시프티에 오신 것을 환영합니다</h1>
-      <div className="w-full flex flex-col gap-4">
-        <div className="flex flex-col gap-4 w-full">
-          <Button kind="a" href="login">
-            로그인
-          </Button>
-          <Button kind="a" href="signup">
-            회원가입
-          </Button>
-        </div>
-        <span>&copy; faketee2022</span>
-      </div>
+      <h1 className="font-bold">메인 페이지 제목</h1>
+      <div>메인 페이지 내용</div>
     </MainPageWrapper>
   );
 }

--- a/frontend/src/Pages/Main/index.tsx
+++ b/frontend/src/Pages/Main/index.tsx
@@ -2,16 +2,19 @@ import { useEffect } from 'react';
 
 import Button from '@/Components/Button';
 import useHeader from '@/Components/Header/Hooks/useHeader';
+import useFooter from '@/Components/Footer/Hooks/useFooter';
 
 import { MainPageWrapper } from './style';
 
 export default function MainPage() {
   const { changeHeaderState } = useHeader();
+  const { changeFooterState } = useFooter();
 
   useEffect(() => {
     changeHeaderState({
       visible: false,
     });
+    changeFooterState({ visible: false });
   }, []);
 
   return (

--- a/frontend/src/Pages/Main/style.tsx
+++ b/frontend/src/Pages/Main/style.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
 
 export const MainPageWrapper = ({ children }: { children: React.ReactNode }) => (
-  <main className="flex flex-col text-center h-full items-center justify-around">{children}</main>
+  <main className="flex flex-col text-center h-3/4 items-center justify-around">{children}</main>
 );

--- a/frontend/src/Pages/Signup/index.tsx
+++ b/frontend/src/Pages/Signup/index.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react';
 import useHeader from '@/Components/Header/Hooks/useHeader';
 import Button from '@/Components/Button';
 import Input from '@/Components/Input';
+import useFooter from '@/Components/Footer/Hooks/useFooter';
 
 import { SignupPageWrapper } from './style';
 
@@ -24,12 +25,14 @@ const onDoubleCheckBtn = () => {
 
 export default function SignupPage() {
   const { changeHeaderState } = useHeader();
+  const { changeFooterState } = useFooter();
 
   useEffect(() => {
     changeHeaderState({
       visible: true,
       leftBtn: 'back',
     });
+    changeFooterState({ visible: false });
   }, []);
 
   return (

--- a/frontend/src/Pages/Signup/index.tsx
+++ b/frontend/src/Pages/Signup/index.tsx
@@ -1,13 +1,13 @@
 import axios from 'axios';
 import { useEffect } from 'react';
 
+import useHeader from '@/Components/Header/Hooks/useHeader';
 import Button from '@/Components/Button';
 import Input from '@/Components/Input';
-import useHeader from '@/Components/Header/Hooks/useHeader';
 
 import { SignupPageWrapper } from './style';
 
-const handleDoubleCheckBtn = () => {
+const onDoubleCheckBtn = () => {
   axios
     .post(`${import.meta.env.VITE_APP_API}/api/account/register`, {
       email: 'rfv1479@ajou.ac.kr',

--- a/frontend/src/Pages/Signup/index.tsx
+++ b/frontend/src/Pages/Signup/index.tsx
@@ -39,7 +39,7 @@ export default function SignupPage() {
     <SignupPageWrapper>
       <h1 className="font-bold">회원가입</h1>
       <form method="post" className="w-full flex flex-col gap-2 text-left">
-        <Input label="이메일" placeholder="이메일을 입력하세요" message="에러 메세지 입니다" />
+        <Input label="이메일" placeholder="이메일을 입력하세요" errorMsg="에러 메세지 입니다" />
         <Button
           onClick={() => {
             alert('중복 확인');

--- a/frontend/src/Pages/commute/index.tsx
+++ b/frontend/src/Pages/commute/index.tsx
@@ -3,6 +3,8 @@ import { useEffect } from 'react';
 import useHeader from '@/Components/Header/Hooks/useHeader';
 import useFooter from '@/Components/Footer/Hooks/useFooter';
 
+import { CommutePageWrapper } from './style';
+
 export default function CommutePage() {
   const { changeHeaderState } = useHeader();
   const { changeFooterState } = useFooter();
@@ -18,8 +20,8 @@ export default function CommutePage() {
   }, []);
 
   return (
-    <>
+    <CommutePageWrapper>
       <div>출퇴근기록 페이지 입니다</div>
-    </>
+    </CommutePageWrapper>
   );
 }

--- a/frontend/src/Pages/commute/index.tsx
+++ b/frontend/src/Pages/commute/index.tsx
@@ -3,26 +3,23 @@ import { useEffect } from 'react';
 import useHeader from '@/Components/Header/Hooks/useHeader';
 import useFooter from '@/Components/Footer/Hooks/useFooter';
 
-import { MainPageWrapper } from './style';
-
-export default function MainPage() {
+export default function CommutePage() {
   const { changeHeaderState } = useHeader();
   const { changeFooterState } = useFooter();
 
   useEffect(() => {
     changeHeaderState({
       visible: true,
-      leftBtn: 'back',
+      leftBtn: 'empty',
       rightBtn: 'empty',
-      headerTitle: '메인 페이지',
+      headerTitle: '출퇴근기록 페이지',
     });
-    changeFooterState({ visible: true, isSelected: 'home' });
+    changeFooterState({ visible: true, isSelected: 'commute' });
   }, []);
 
   return (
-    <MainPageWrapper>
-      <h1 className="font-bold">메인 페이지 제목</h1>
-      <div>메인 페이지 내용</div>
-    </MainPageWrapper>
+    <>
+      <div>출퇴근기록 페이지 입니다</div>
+    </>
   );
 }

--- a/frontend/src/Pages/commute/style.tsx
+++ b/frontend/src/Pages/commute/style.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export const MainPageWrapper = ({ children }: { children: React.ReactNode }) => (
+export const CommutePageWrapper = ({ children }: { children: React.ReactNode }) => (
   <main className="flex flex-col text-center bg-gray-100 h-screen items-center justify-around">
     {children}
   </main>

--- a/frontend/src/Pages/workPlan/index.tsx
+++ b/frontend/src/Pages/workPlan/index.tsx
@@ -3,6 +3,8 @@ import { useEffect } from 'react';
 import useHeader from '@/Components/Header/Hooks/useHeader';
 import useFooter from '@/Components/Footer/Hooks/useFooter';
 
+import { WorkPlanPageWrapper } from './style';
+
 export default function WorkPlanPage() {
   const { changeHeaderState } = useHeader();
   const { changeFooterState } = useFooter();
@@ -18,8 +20,8 @@ export default function WorkPlanPage() {
   }, []);
 
   return (
-    <>
+    <WorkPlanPageWrapper>
       <div>근무일정 페이지 입니다</div>
-    </>
+    </WorkPlanPageWrapper>
   );
 }

--- a/frontend/src/Pages/workPlan/index.tsx
+++ b/frontend/src/Pages/workPlan/index.tsx
@@ -3,26 +3,23 @@ import { useEffect } from 'react';
 import useHeader from '@/Components/Header/Hooks/useHeader';
 import useFooter from '@/Components/Footer/Hooks/useFooter';
 
-import { MainPageWrapper } from './style';
-
-export default function MainPage() {
+export default function WorkPlanPage() {
   const { changeHeaderState } = useHeader();
   const { changeFooterState } = useFooter();
 
   useEffect(() => {
     changeHeaderState({
       visible: true,
-      leftBtn: 'back',
+      leftBtn: 'empty',
       rightBtn: 'empty',
-      headerTitle: '메인 페이지',
+      headerTitle: '근무일정 페이지',
     });
-    changeFooterState({ visible: true, isSelected: 'home' });
+    changeFooterState({ visible: true, isSelected: 'workplan' });
   }, []);
 
   return (
-    <MainPageWrapper>
-      <h1 className="font-bold">메인 페이지 제목</h1>
-      <div>메인 페이지 내용</div>
-    </MainPageWrapper>
+    <>
+      <div>근무일정 페이지 입니다</div>
+    </>
   );
 }

--- a/frontend/src/Pages/workPlan/style.tsx
+++ b/frontend/src/Pages/workPlan/style.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export const MainPageWrapper = ({ children }: { children: React.ReactNode }) => (
+export const WorkPlanPageWrapper = ({ children }: { children: React.ReactNode }) => (
   <main className="flex flex-col text-center bg-gray-100 h-screen items-center justify-around">
     {children}
   </main>

--- a/frontend/src/Stores/layout.ts
+++ b/frontend/src/Stores/layout.ts
@@ -17,6 +17,7 @@ export const isFooterLayoutState = atom<FooterStateKindsOf>({
   key: 'isFooterLayoutState',
   default: {
     visible: false,
+    isSelected: 'home',
   },
 });
 

--- a/frontend/src/Stores/layout.ts
+++ b/frontend/src/Stores/layout.ts
@@ -1,8 +1,9 @@
 import { atom, selector } from 'recoil';
 
-import { HeaderProps } from '@/Components/Header/types';
+import { HeaderStateKindsOf } from '@/Components/Header/types';
+import { FooterStateKindsOf } from '@/Components/Footer';
 
-export const isHeaderLayoutState = atom<HeaderProps>({
+export const isHeaderLayoutState = atom<HeaderStateKindsOf>({
   key: 'isHeaderLayoutState',
   default: {
     visible: true,
@@ -12,10 +13,25 @@ export const isHeaderLayoutState = atom<HeaderProps>({
   },
 });
 
+export const isFooterLayoutState = atom<FooterStateKindsOf>({
+  key: 'isFooterLayoutState',
+  default: {
+    visible: false,
+  },
+});
+
 export const setIsHeaderLayoutState = selector({
   key: 'setIsHeaderLayoutState',
   get: ({ get }) => get(isHeaderLayoutState),
   set: ({ set }, newHeaderLayoutState) => {
     set(isHeaderLayoutState, newHeaderLayoutState);
+  },
+});
+
+export const setIsFooterLayoutState = selector({
+  key: 'setIsFooterLayoutState',
+  get: ({ get }) => get(isFooterLayoutState),
+  set: ({ set }, newFooterLayoutState) => {
+    set(isFooterLayoutState, newFooterLayoutState);
   },
 });

--- a/frontend/src/Styles/index.css
+++ b/frontend/src/Styles/index.css
@@ -47,3 +47,9 @@ caption {
   align-items: center;
   justify-content: center;
 }
+
+p {
+  font-size : 0.875rem;
+  text-align: center;
+  line-height: 160%;
+}

--- a/frontend/src/Styles/index.css
+++ b/frontend/src/Styles/index.css
@@ -53,3 +53,61 @@ p {
   text-align: center;
   line-height: 160%;
 }
+
+/* =================================================================
+/* animations */
+.animation-slide-in-right {
+  animation : slide-in-right .55s ease-in-out;
+}
+
+.animation-slide-out-left {
+  animation : slide-out-left .55s ease-in-out;
+}
+
+.animation-fade-in {
+  animation : fade-in .55s ease-in-out;
+}
+
+.animation-fade-out {
+  animation : fade-out .55s ease-in-out;
+}
+
+@keyframes slide-in-right {
+  0% {
+    transform: translateX(-100%);
+    opacity: 0;
+  }
+  100% {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+@keyframes slide-out-left {
+  0% {
+    transform: translateX(0);
+    opacity: 1;
+  }
+  100% {
+    transform: translateX(-100%);
+    opacity: 0;
+  }
+}
+
+@keyframes fade-in {
+  0% {
+    opacity : 0;
+  }
+  100% {
+    opacity : .5;
+  }
+}
+
+@keyframes fade-out {
+  0% {
+    opacity : 0.5;
+  }
+  100% {
+    opacity : 0;
+  }
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,11 +1,12 @@
 import React, { Suspense } from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
-import './Styles/index.css';
-import './Styles/font.css';
 import { RecoilRoot } from 'recoil';
 
 import App from './App';
+
+import './Styles/font.css';
+import './Styles/index.css';
 
 ReactDOM.createRoot(document.getElementById('root')! as HTMLElement).render(
   <React.StrictMode>


### PR DESCRIPTION
### 🔨 관련 이슈

---

#9

### 📝 설명

---

- 메인페이지 레이아웃을 설정했습니다.
- `useRef`을 이용하여 DOM Animation을 추가하였습니다.
- `ComponentMap`을 이용하여 조건별로 버튼을 다르게 렌더링할 수 있도록 재사용성을 높였습니다.

**Preview 확인** :  https://faketee-8a8c9--feat-9-mainpage-gxbt8as2.web.app

closed #9

### 📷 사진

---
![image](https://github.com/dev-hsyang/Faketee-v1.0.2/assets/79848632/cbd8b07f-d892-4242-9386-691c8334b392)